### PR TITLE
Make it easier to follow manual install instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,8 @@ Then add this line to your ``.zshrc``
 Source the plugin shell script in your `~/.zshrc` profile. For example
 
 ::
-
-   source $HOME/zsh-autoswitch-virtualenv/autoswitch_virtualenv.plugin.zsh
+   git clone "https://github.com/MichaelAquilina/zsh-autoswitch-virtualenv.git" "$ZSH_CUSTOM/plugins/autoswitch_virtualenv"
+   source $ZSH_CUSTOM/plugins/autoswitch_virtualenv/autoswitch_virtualenv.plugin.zsh
 
 
 Pipenv Integration


### PR DESCRIPTION
Not sure if the repetition of the git clone is the best (it's literally a few lines above), but if someone skips straight to "manual install" they could easily miss that.